### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,5 @@
     "freeport": "^1.0.5",
     "handlebars": "^4.0.5",
     "node-uuid": "^1.4.7",
-    "rpi-gpio": "^0.7.0"
   }
 }


### PR DESCRIPTION
Removes the rpi-gio dependency which seems unnecessary and which causes issues

```
> epoll@0.1.22 install /home/pi/.node-red/node_modules/epoll
> node-gyp rebuild

make: Entering directory '/home/pi/.node-red/node_modules/epoll/build'
  CXX(target) Release/obj.target/epoll/src/epoll.o
In file included from ../node_modules/nan/nan.h:192:0,
                 from ../src/epoll.cc:15:
../node_modules/nan/nan_maybe_43_inl.h: In function ‘Nan::Maybe<bool> Nan::ForceSet(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Value>, v8::PropertyAttribute)’:
../node_modules/nan/nan_maybe_43_inl.h:112:15: error: ‘class v8::Object’ has no member named ‘ForceSet’
   return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
               ^~~~~~~~
In file included from ../src/epoll.cc:15:0:
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Value> Nan::MakeCallback(v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*)’:
../node_modules/nan/nan.h:835:60: warning: ‘v8::Local<v8:...
```